### PR TITLE
TIDY BCE

### DIFF
--- a/request_test.go
+++ b/request_test.go
@@ -541,3 +541,20 @@ func TestDecodeEmbeddedStructs(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func BenchmarkDecode(b *testing.B) {
+	var err error
+
+	var req struct {
+		Value []string `query:"value"`
+		OK    bool     `query:"deep[ok]"`
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/?value=one,two,three&deep[ok]=1", nil)
+
+	for range b.N {
+		err = Decode(r, &req)
+	}
+
+	_ = err
+}


### PR DESCRIPTION
```sh
✗ benchstat a.txt b.txt                         
goos: darwin
goarch: arm64
pkg: go.expect.digital/request
          │    a.txt    │             b.txt             │
          │   sec/op    │   sec/op     vs base          │
Decode-12   1.039µ ± 2%   1.037µ ± 1%  ~ (p=0.403 n=10)

          │    a.txt     │                b.txt                │
          │     B/op     │     B/op      vs base               │
Decode-12   1.266Ki ± 0%   1.234Ki ± 0%  -2.47% (p=0.000 n=10)

          │   a.txt    │             b.txt              │
          │ allocs/op  │ allocs/op   vs base            │
Decode-12   18.00 ± 0%   18.00 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```